### PR TITLE
sort submission into directories based on their relevancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Parameter explanation:
 ## Result
 
 After execution the target directory will contain a subdirectory for each user.
-These subdirectories can contain the following content:
+
+### Single file mode
+
+If there was only one file associated with the exercises, these subdirectories can contain the following content:
 
 - `name.java`: Last submitted version.
 - `name - ASSESSED AFTER SUBMIT.java`: Version that was scored (but not submitted) after the last submitted version.
@@ -30,3 +33,7 @@ These subdirectories can contain the following content:
 - `error.txt`: Created if the server responded with an error when trying to download the submission page. Contains error details.
 
 All `*.java` files will also contain an initial comment with the url to the submission page, and the score of the submission.
+
+### Multi file mode
+
+If more than one file are associated with the  exercise, the student directories may contain one or more subdirectories labeled `SUBMIT`, `ASSESSED AFTER SUBMIT`, `ASSESSED ONLY`, `NO ASSESS OR SUBMIT` or `TOP SCORE`. The meanings are the same as described above with `SUBMIT` being equivalent to no suffix (`name.java`). In this mode the metadata (url and score) will be placed in files called `url.txt` and `score.txt` withing the different subdirectories.

--- a/src/main/kotlin/io/github/codeocean_scraper/RelevancyType.kt
+++ b/src/main/kotlin/io/github/codeocean_scraper/RelevancyType.kt
@@ -5,5 +5,18 @@ enum class RelevancyType {
     ASSESSED_AFTER_SUBMIT,
     ASSESSED_ONLY,
     NO_ASSESS_OR_SUBMIT,
-    TOP_SCORE
+    TOP_SCORE;
+
+    fun toFileString() = when(this) {
+        RelevancyType.SUBMITTED -> "SUBMIT"
+        RelevancyType.ASSESSED_AFTER_SUBMIT -> "ASSESSED AFTER SUBMIT"
+        RelevancyType.ASSESSED_ONLY -> "ASSESSED ONLY"
+        RelevancyType.NO_ASSESS_OR_SUBMIT -> "NO ASSESS OR SUBMIT"
+        RelevancyType.TOP_SCORE -> "TOP SCORE"
+    }
+
+    fun toFilePostfix() = when(this) {
+        RelevancyType.SUBMITTED -> ""
+        else -> " - ${this.toFileString()}"
+    }
 }

--- a/src/main/kotlin/io/github/codeocean_scraper/analysis/StudentSubmissionsPage.kt
+++ b/src/main/kotlin/io/github/codeocean_scraper/analysis/StudentSubmissionsPage.kt
@@ -14,20 +14,12 @@ import org.jsoup.nodes.Element
 import java.nio.file.Files
 import java.nio.file.Path
 
-
-private val HEADER_TEMPLATE = """//
-// Submissions page: %s
-// Score: %s
-//
-
-"""
-
-private fun relevancySuffix(relevancyType: RelevancyType) = when(relevancyType) {
-        RelevancyType.SUBMITTED -> ""
-        RelevancyType.ASSESSED_AFTER_SUBMIT -> " - ASSESSED AFTER SUBMIT"
-        RelevancyType.ASSESSED_ONLY -> " - ASSESSED ONLY"
-        RelevancyType.NO_ASSESS_OR_SUBMIT -> " - NO ASSESS OR SUBMIT"
-        RelevancyType.TOP_SCORE -> " - TOP SCORE"
+private fun relevancyDir(relevancyType: RelevancyType) = when(relevancyType) {
+        RelevancyType.SUBMITTED -> "SUBMIT"
+        RelevancyType.ASSESSED_AFTER_SUBMIT -> "ASSESSED AFTER SUBMIT"
+        RelevancyType.ASSESSED_ONLY -> "ASSESSED ONLY"
+        RelevancyType.NO_ASSESS_OR_SUBMIT -> "NO ASSESS OR SUBMIT"
+        RelevancyType.TOP_SCORE -> "TOP SCORE"
 }
 
 private fun parseSubmissions(
@@ -101,14 +93,17 @@ private fun saveFiles(
 ) {
     for ((relevancy, submission) in relevantSubmissions) {
         val files = submissionFiles[submission.id]!!
+
+        val dir = studentDirectory.resolve(relevancyDir(relevancy));
+        Files.createDirectories(dir);
+
+        dir.resolve("SCORE").toFile().writeText((submission.score?.toString() ?: "Not scored") + "\n");
+        dir.resolve("URL").toFile().writeText(submissionsPageUrl + "\n");
+
         for (file in files) {
-            val fileName = "${file.name}${relevancySuffix(relevancy)}.java"
-            val filePath = studentDirectory.resolve(fileName)
-            val header = HEADER_TEMPLATE.format(
-                    submissionsPageUrl,
-                    submission.score?.toString() ?: "Not scored"
-            )
-            filePath.toFile().writeText(header + file.content)
+            val fileName = "${file.name}.java"
+            val filePath = dir.resolve(fileName)
+            filePath.toFile().writeText(file.content)
         }
     }
 }

--- a/src/main/kotlin/io/github/codeocean_scraper/analysis/StudentSubmissionsPage.kt
+++ b/src/main/kotlin/io/github/codeocean_scraper/analysis/StudentSubmissionsPage.kt
@@ -106,8 +106,8 @@ private fun saveFiles(
             header = ""
             postfix = ""
 
-            dir.resolve("SCORE").toFile().writeText(submissionScore + "\n");
-            dir.resolve("URL").toFile().writeText(submissionsPageUrl + "\n");
+            dir.resolve("score.txt").toFile().writeText(submissionScore + "\n");
+            dir.resolve("url.txt").toFile().writeText(submissionsPageUrl + "\n");
         } else {
             dir = studentDirectory
             postfix = relevancy.toFilePostfix()


### PR DESCRIPTION
This makes the output more suitable for multi-file submissions, although it probably makes the situation worse for single file submissions.

Any suggestions for a solution which would fit both use cases?