### PR TITLE
Enable login with the cli while caching session keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ Batch download student submission from codeocean
 
 ## Running
 
-Set the environment variable `CO_COOKIE` to your session key (see below) and execute with `java -jar path/to/jar targetDirectory statisticsPageUrl`.
+Execute `java -jar path/to/jar exerciseUrl targetDirectory`
 
 Parameter explanation:
+- *exerciseUrl:* URL to the statistics page of the exercise you want to download.
+  Should have the format `https://codeocean.url/exercises/<someId>/statistics`.
 - *targetDirectory:* All downloaded submissions will be saved under this directory. The directory must already exist.
-- *statisticsPageUrl:* Url to the statistics page of the exercise you want to download the submissions for.
-- *session key:* Session key for authentication. Obtained by logging into CodeOcean in your browser, then copying the content of the `_hands-on-programming_session` cookie.
+
+### Authentication
+
+The scraper uses session keys to authenticate with CodeOcean.
+These are cached per CodeOcean installation in `~/.codeocean-scraper.json`.
+If no cached session key exists or the cached one has been invalidated, you are prompted for an email and password to sign in.
 
 ## Result
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = '1.0.1-2'
+        kotlinVersion = '1.0.2'
     }
     repositories {
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.incremental=true

--- a/src/main/kotlin/io/github/codeocean_scraper/Cache.kt
+++ b/src/main/kotlin/io/github/codeocean_scraper/Cache.kt
@@ -1,0 +1,20 @@
+package io.github.codeocean_scraper
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import java.io.File
+
+private val cacheFile = File(System.getProperty("user.home"), ".codeocean-scraper.json")
+
+class Cache(val sessionKeys: MutableMap<String, String>) {
+    fun save(mapper: ObjectMapper) {
+        mapper.writeValue(cacheFile, this)
+    }
+}
+
+fun loadCache(mapper: ObjectMapper): Cache {
+    return when {
+        cacheFile.exists() -> mapper.readValue<Cache>(cacheFile)
+        else -> Cache(mutableMapOf())
+    }
+}

--- a/src/main/kotlin/io/github/codeocean_scraper/Login.kt
+++ b/src/main/kotlin/io/github/codeocean_scraper/Login.kt
@@ -1,0 +1,39 @@
+package io.github.codeocean_scraper
+
+import org.jsoup.Connection
+import org.jsoup.Jsoup
+import java.net.URL
+
+private fun login(baseUrl: URL, email: String, password: String): String {
+    val loginUrl = URL(baseUrl, "/sign_in")
+    val pageResponse = Jsoup.connect(loginUrl.toString())
+                            .method(Connection.Method.GET)
+                            .execute()
+    val doc = pageResponse.parse()
+    val token = doc.select("input[name=\"authenticity_token\"]").first().`val`()
+    val formData = mapOf(
+            "utf-8" to "✓",
+            "authenticity_token" to token,
+            "email" to email,
+            "password" to password,
+            "commit" to "Sign+In"
+    )
+    val loginResponse = Jsoup.connect(URL(baseUrl, "/sessions").toString())
+                             .method(Connection.Method.POST)
+                             .data(formData)
+                             .cookies(pageResponse.cookies())
+                             .execute()
+    return loginResponse.cookie("_hands-on-programming_session")
+}
+
+fun interactiveLogin(baseUrl: URL): String {
+    val console = System.console()
+    if (console == null) {
+        System.err.println("Can't get console object to read email and password. Aborting!")
+        System.exit(1)
+    }
+
+    val email = console.readLine("Email: ")
+    val password = String(console.readPassword("Password: "))
+    return login(baseUrl, email, password)
+}

--- a/src/main/kotlin/io/github/codeocean_scraper/PageFetcher.kt
+++ b/src/main/kotlin/io/github/codeocean_scraper/PageFetcher.kt
@@ -1,12 +1,24 @@
 package io.github.codeocean_scraper
 
 import org.jsoup.Jsoup
+import java.net.URL
+
+private val cookieName = "_hands-on-programming_session"
 
 class PageFetcher(val sessionKey: String) {
     fun fetch(url: String)
         = Jsoup.connect(url)
-               .cookie("_hands-on-programming_session", sessionKey)
+               .cookie(cookieName, sessionKey)
                .maxBodySize(128 * 1024 * 1024)
                .timeout(0)
                .get()
+}
+
+fun isValidSessionKey(baseUrl: URL, sessionKey: String): Boolean {
+    // Sign in page redirects to homepage if session key is valid
+    val signInUrl = URL(baseUrl, "/sign_in")
+    val response = Jsoup.connect(signInUrl.toString())
+                        .cookie(cookieName, sessionKey)
+                        .execute()
+    return response.url() == baseUrl
 }

--- a/src/main/kotlin/io/github/codeocean_scraper/analysis/StatisticsPage.kt
+++ b/src/main/kotlin/io/github/codeocean_scraper/analysis/StatisticsPage.kt
@@ -10,5 +10,3 @@ fun findStudentSubmissionPages(
     val links = table.select("tbody > tr > td > a")
     return links.map { it.text() to (baseUrl + it.attr("href")) }
 }
-
-

--- a/src/main/kotlin/io/github/codeocean_scraper/analysis/StudentSubmissionsPage.kt
+++ b/src/main/kotlin/io/github/codeocean_scraper/analysis/StudentSubmissionsPage.kt
@@ -1,7 +1,6 @@
 package io.github.codeocean_scraper.analysis
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.codeocean_scraper.PageFetcher
 import io.github.codeocean_scraper.RelevancyType
@@ -136,7 +135,8 @@ fun analyseAndSave(
         submissionsPageUrl: String,
         fetcher: PageFetcher,
         studentName: String,
-        studentsDirectory: Path
+        studentsDirectory: Path,
+        mapper: ObjectMapper
 ) {
     require(studentsDirectory.toFile().isDirectory) { "Students directory must be a directory" }
     val studentDirectory = createStudentDirectory(studentsDirectory, studentName)
@@ -149,7 +149,6 @@ fun analyseAndSave(
     }
 
     val dataNode = document.select("#data").first()
-    val mapper = jacksonObjectMapper()
     val submissions = parseSubmissions(dataNode, mapper)
     val relevantSubmissions = findRelevantSubmissions(submissions)
     val submissionFiles = parseSubmissionFiles(dataNode, mapper)


### PR DESCRIPTION
Alleviates the need to extract the session cookie from a browser. Session keys are cached in `~/.codeocean-scraper.json`, one per base CodeOcean url. The user is requested to enter an email plus password when no session key has been cached, or the cached one has been invalidated.

I also upgraded Kotlin to version 1.0.2, because I was hitting a compiler bug of version 1.0.1-2 in the process. The new version also enables incremental compilation for gradle, to speed up compiling.